### PR TITLE
Fix error when configuring a contentfile in / (#18)

### DIFF
--- a/cmdline/state.c
+++ b/cmdline/state.c
@@ -855,7 +855,7 @@ void state_config(struct snapraid_state* state, const char* path, const char* co
 			pathimport(device, sizeof(device), buffer);
 			slash = strrchr(device, '/');
 			if (slash)
-				*slash = 0;
+				*(slash + 1) = 0;
 			else
 				pathcpy(device, sizeof(device), ".");
 			if (stat(device, &st) == 0) {


### PR DESCRIPTION
When using this config line:
content /snapraid.content
SnapRAID throws this error:
Error accessing 'content' dir '' specification in '/etc/snapraid.conf' at line 17

This commit fixes that by not replacing the rightmost slash with NUL but instead the char immediately after the slash.